### PR TITLE
SONG Sequence Read returns null instead of empty strings

### DIFF
--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/SongSequencingRead.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/SongSequencingRead.java
@@ -18,6 +18,7 @@
 package org.icgc.dcc.repository.song.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import lombok.val;
 
 public class SongSequencingRead extends SongExperiment {
 
@@ -40,7 +41,10 @@ public class SongSequencingRead extends SongExperiment {
   }
 
   public String get(Field f) {
-    return get(f.toString());
+    // JsonContainer.get() returns empty String if key doesn't exist, in this case we want null to ensure we don't
+    //  index an empty facet value
+    val value = get(f.toString());
+    return value.isEmpty() ? null : value;
   }
 
   public enum Field {


### PR DESCRIPTION
Some fields for entities imported from SONG were indexed with facet values of empty strings, instead of missing data.

The culprit is a wrapper on Jackson JSON object that would get() a String value using the asText() method which opts to return empty string when the key/value is missing.

By modifying the get() method in SongSequencingRead we make it so that all usages in the SongProcessor will get null (gets indexed as empty value) instead of "" (empty string which gets indexed wrong).

This affects the values retrieved for:
 - experimental strategy
 - reference genome build
 - analysis software