### PR TITLE
feat(SongImporter): updated for new url param for getAnalysesForStudy

### DIFF
--- a/dcc-repository-aws/src/main/java/org/icgc/dcc/repository/aws/AWSImporter.java
+++ b/dcc-repository-aws/src/main/java/org/icgc/dcc/repository/aws/AWSImporter.java
@@ -17,22 +17,25 @@
  */
 package org.icgc.dcc.repository.aws;
 
-import org.icgc.dcc.repository.core.RepositoryFileContext;
-import org.icgc.dcc.repository.core.model.Repositories;
-
+import com.google.common.collect.ImmutableSet;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.icgc.dcc.repository.core.RepositoryFileContext;
+import org.icgc.dcc.repository.core.model.Repositories;
 import org.icgc.dcc.repository.song.SongImporter;
+
+import static org.icgc.dcc.repository.song.model.AnalysisStates.PUBLISHED;
 
 @Slf4j
 public class AWSImporter extends SongImporter {
 
   public AWSImporter(@NonNull RepositoryFileContext context) {
     super(
-      context,
-      Repositories.getAWSRepository(),
-      context.getAwsUrl(),
-      context.getAwsToken());
+        context,
+        Repositories.getAWSRepository(),
+        context.getAwsUrl(),
+        context.getAwsToken(),
+        ImmutableSet.of(PUBLISHED) );
   }
 
 }

--- a/dcc-repository-collab/src/main/java/org/icgc/dcc/repository/collab/CollabImporter.java
+++ b/dcc-repository-collab/src/main/java/org/icgc/dcc/repository/collab/CollabImporter.java
@@ -17,22 +17,25 @@
  */
 package org.icgc.dcc.repository.collab;
 
-import org.icgc.dcc.repository.song.SongImporter;
-import org.icgc.dcc.repository.core.RepositoryFileContext;
-import org.icgc.dcc.repository.core.model.Repositories;
-
+import com.google.common.collect.ImmutableSet;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.icgc.dcc.repository.core.RepositoryFileContext;
+import org.icgc.dcc.repository.core.model.Repositories;
+import org.icgc.dcc.repository.song.SongImporter;
+
+import static org.icgc.dcc.repository.song.model.AnalysisStates.PUBLISHED;
 
 @Slf4j
 public class CollabImporter extends SongImporter {
 
   public CollabImporter(@NonNull RepositoryFileContext context) {
     super(
-      context,
-      Repositories.getCollabRepository(),
-      context.getCollabUrl(),
-      context.getCollabToken());
+        context,
+        Repositories.getCollabRepository(),
+        context.getCollabUrl(),
+        context.getCollabToken(),
+        ImmutableSet.of(PUBLISHED));
   }
 
 }

--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/SongImporter.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/SongImporter.java
@@ -21,34 +21,41 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.icgc.dcc.repository.core.RepositoryFileContext;
-import org.icgc.dcc.repository.core.model.Repositories;
 import org.icgc.dcc.repository.core.model.Repository;
 import org.icgc.dcc.repository.core.model.RepositoryFile;
 import org.icgc.dcc.repository.core.util.GenericRepositorySourceFileImporter;
 import org.icgc.dcc.repository.song.core.SongProcessor;
+import org.icgc.dcc.repository.song.model.AnalysisStates;
 import org.icgc.dcc.repository.song.model.SongAnalysis;
 import org.icgc.dcc.repository.song.reader.SongClient;
 
 import java.net.URL;
+import java.util.Set;
 
 @Slf4j
 public abstract class SongImporter extends GenericRepositorySourceFileImporter {
+
   @NonNull
   private final SongClient reader;
   @NonNull
   private final SongProcessor processor;
+  @NonNull
+  private final Set<AnalysisStates> analysisStates;
 
-  public SongImporter(@NonNull RepositoryFileContext context, @NonNull Repository repository, @NonNull URL songUrl, @NonNull String songToken) {
+  public SongImporter(@NonNull RepositoryFileContext context, @NonNull Repository repository,
+      @NonNull URL songUrl, @NonNull String songToken, @NonNull Set<AnalysisStates> analysisStates) {
     super(repository.getSource(), context, log);
     this.reader = new SongClient(songUrl, songToken);
     this.processor = new SongProcessor(context, repository);
+    this.analysisStates = analysisStates;
   }
 
   public SongImporter(@NonNull Repository repository, @NonNull RepositoryFileContext context,
-    SongClient reader, SongProcessor processor) {
+    SongClient reader, SongProcessor processor, @NonNull Set<AnalysisStates> analysisStates) {
     super(repository.getSource(), context, log);
     this.reader = reader;
     this.processor = processor;
+    this.analysisStates = analysisStates;
   }
 
   @Override
@@ -62,7 +69,7 @@ public abstract class SongImporter extends GenericRepositorySourceFileImporter {
 
   @SneakyThrows
   private Iterable<SongAnalysis> readAnalysis() {
-    return reader.readAnalyses();
+    return reader.readAnalyses(analysisStates);
   }
 
 }

--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/core/SongProcessor.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/core/SongProcessor.java
@@ -25,7 +25,15 @@ import org.icgc.dcc.repository.core.RepositoryFileContext;
 import org.icgc.dcc.repository.core.RepositoryFileProcessor;
 import org.icgc.dcc.repository.core.model.Repository;
 import org.icgc.dcc.repository.core.model.RepositoryFile;
-import org.icgc.dcc.repository.core.model.RepositoryFile.*;
+import org.icgc.dcc.repository.core.model.RepositoryFile.AnalysisMethod;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataBundle;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataCategorization;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataType;
+import org.icgc.dcc.repository.core.model.RepositoryFile.Donor;
+import org.icgc.dcc.repository.core.model.RepositoryFile.FileCopy;
+import org.icgc.dcc.repository.core.model.RepositoryFile.IndexFile;
+import org.icgc.dcc.repository.core.model.RepositoryFile.ReferenceGenome;
+import org.icgc.dcc.repository.core.model.RepositoryFile.Study;
 import org.icgc.dcc.repository.song.model.SongAnalysis;
 import org.icgc.dcc.repository.song.model.SongFile;
 import org.icgc.dcc.repository.song.model.SongSequencingRead;
@@ -41,14 +49,17 @@ import static java.util.stream.StreamSupport.stream;
 import static org.icgc.dcc.repository.song.model.SongAnalysis.Field.analysisId;
 import static org.icgc.dcc.repository.song.model.SongAnalysis.Field.analysisType;
 import static org.icgc.dcc.repository.song.model.SongDonor.Field.donorSubmitterId;
-import static org.icgc.dcc.repository.song.model.SongFile.Field.*;
+import static org.icgc.dcc.repository.song.model.SongFile.Field.fileAccess;
+import static org.icgc.dcc.repository.song.model.SongFile.Field.fileMd5sum;
+import static org.icgc.dcc.repository.song.model.SongFile.Field.fileName;
+import static org.icgc.dcc.repository.song.model.SongFile.Field.fileType;
+import static org.icgc.dcc.repository.song.model.SongFile.Field.objectId;
 import static org.icgc.dcc.repository.song.model.SongSample.Field.sampleSubmitterId;
 import static org.icgc.dcc.repository.song.model.SongSequencingRead.Field.alignmentTool;
 import static org.icgc.dcc.repository.song.model.SongSequencingRead.Field.libraryStrategy;
 import static org.icgc.dcc.repository.song.model.SongSequencingRead.Field.referenceGenome;
 import static org.icgc.dcc.repository.song.model.SongSpecimen.Field.specimenSubmitterId;
 import static org.icgc.dcc.repository.song.model.SongSpecimen.Field.specimenType;
-import static org.icgc.dcc.repository.song.model.SongStudy.Field.studyId;
 import static org.icgc.dcc.repository.song.model.SongVariantCall.Field.variantCallingTool;
 
 @Slf4j
@@ -309,14 +320,14 @@ public class SongProcessor extends RepositoryFileProcessor {
   }
 
   Donor getDonor(SongAnalysis a) {
-    val study = a.getStudy();
+    val studyId = a.getStudyId();
     val sample = a.getFirstSample();
     val donor = sample.getDonor();
     val specimen = sample.getSpecimen();
     return new Donor()
       .setStudy(null)
-      .setProjectCode(study.get(studyId))
-      .setPrimarySite(context.getPrimarySite(study.get(studyId)))
+      .setProjectCode(studyId)
+      .setPrimarySite(context.getPrimarySite(studyId))
       .setDonorId(null)
       .setSpecimenId(null)
       .setSpecimenType(singletonList(specimen.get(specimenType)))

--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/AnalysisStates.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/AnalysisStates.java
@@ -1,0 +1,7 @@
+package org.icgc.dcc.repository.song.model;
+
+public enum AnalysisStates {
+  UNPUBLISHED,
+  PUBLISHED,
+  SUPPRESSED
+}

--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/SongAnalysis.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/model/SongAnalysis.java
@@ -32,20 +32,19 @@ public class SongAnalysis extends JsonContainer {
   private final static String FILES = "file";
   private final static String INFO = "info";
   private static final String IS_PCAWG = "isPcawg";
+  private static final String STUDY = "study";
 
   private List<SongFile> files;
   private List<SongSample> samples;
   private SongExperiment experiment;
-  private SongStudy study;
   private Boolean pcawg;
 
-  public SongAnalysis(JsonNode json, JsonNode study) {
+  public SongAnalysis(JsonNode json) {
     super(json);
     setFiles(from(FILES));
     setSamples(from(SAMPLES));
     setExperiment(get(Field.analysisType), from(EXPERIMENT));
     setPcawg(from(INFO));
-    this.study = new SongStudy(study);
   }
 
   public List<SongSample> getSamples() {
@@ -83,8 +82,8 @@ public class SongAnalysis extends JsonContainer {
     f.elements().forEachRemaining(node -> files.add(new SongFile(node)));
   }
 
-  public SongStudy getStudy() {
-    return study;
+  public String getStudyId() {
+    return get(STUDY);
   }
 
   public SongExperiment getExperiment() {

--- a/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/reader/MockSongClient.java
+++ b/dcc-repository-song/src/main/java/org/icgc/dcc/repository/song/reader/MockSongClient.java
@@ -19,18 +19,18 @@ package org.icgc.dcc.repository.song.reader;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.io.Resources;
+import org.icgc.dcc.repository.song.model.AnalysisStates;
 
 import java.net.URL;
+import java.util.Set;
 
 public class MockSongClient extends SongClient {
 
   private String analysesURL;
-  private String studyURL;
   private URL studiesURL;
 
-  public MockSongClient(String analysesFile, String studyFile, String studiesFile) {
+  public MockSongClient(String analysesFile, String studiesFile) {
     analysesURL = analysesFile;
-    studyURL = studyFile;
     studiesURL = resourceFile(studiesFile);
   }
 
@@ -39,17 +39,12 @@ public class MockSongClient extends SongClient {
   }
 
   @Override
-  JsonNode getStudy(String study) {
-    return readJson(resourceFile(study + "/" + studyURL));
-  }
-
-  @Override
   JsonNode getStudies() {
     return readJson(studiesURL);
   }
 
   @Override
-  JsonNode getAnalyses(String study) {
+  JsonNode getAnalyses(String study, Set<AnalysisStates> analysisStates) {
     return readJson(resourceFile(study + "/" + analysesURL));
   }
 

--- a/dcc-repository-song/src/test/java/org/icgc/dcc/repository/song/SongImporterTest.java
+++ b/dcc-repository-song/src/test/java/org/icgc/dcc/repository/song/SongImporterTest.java
@@ -17,24 +17,25 @@
  */
 package org.icgc.dcc.repository.song;
 
-import lombok.val;
+import com.google.common.collect.ImmutableSet;
 import lombok.NonNull;
-import org.icgc.dcc.repository.song.reader.MockSongClient;
-import org.icgc.dcc.repository.song.SongImporter;
+import lombok.val;
 import org.icgc.dcc.repository.core.RepositoryFileContext;
 import org.icgc.dcc.repository.core.model.Repositories;
 import org.icgc.dcc.repository.core.model.Repository;
-import org.icgc.dcc.repository.song.SongImporter;
 import org.icgc.dcc.repository.song.core.SongProcessor;
+import org.icgc.dcc.repository.song.model.AnalysisStates;
+import org.icgc.dcc.repository.song.reader.MockSongClient;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Set;
 
 import static org.icgc.dcc.repository.core.util.RepositoryFileContexts.newLocalRepositoryFileContext;
+import static org.icgc.dcc.repository.song.model.AnalysisStates.PUBLISHED;
 
 @Ignore("For development only -- requires mongod to be running on localhost")
-
 public class SongImporterTest {
 
   @Test
@@ -42,16 +43,17 @@ public class SongImporterTest {
     val context = newLocalRepositoryFileContext();
     val repository = Repositories.getCollabRepository();
 
-    val reader = new MockSongClient("analyses.json", "study.json", "studies.json");
+    val reader = new MockSongClient("analyses.json", "studies.json");
     val processor = new SongProcessor(context, repository);
-    val importer = new TestImporter(repository, context, reader, processor);
+    val analysisStates = ImmutableSet.of(PUBLISHED);
+    val importer = new TestImporter(repository, context, reader, processor, analysisStates);
     importer.execute();
   }
 
   private class TestImporter extends SongImporter {
     public TestImporter(@NonNull Repository repository, @NonNull RepositoryFileContext context,
-                        MockSongClient reader, SongProcessor processor) {
-      super(repository, context, reader, processor);
+                        MockSongClient reader, SongProcessor processor, @NonNull Set<AnalysisStates> analysisStates) {
+      super(repository, context, reader, processor, analysisStates);
     }
   }
 

--- a/dcc-repository-song/src/test/java/org/icgc/dcc/repository/song/reader/SongClientTest.java
+++ b/dcc-repository-song/src/test/java/org/icgc/dcc/repository/song/reader/SongClientTest.java
@@ -1,22 +1,23 @@
 /*
- * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.                             
- *                                                                                                               
+ * Copyright (c) 2016 The Ontario Institute for Cancer Research. All rights reserved.
+ *
  * This program and the accompanying materials are made available under the terms of the GNU Public License v3.0.
- * You should have received a copy of the GNU General Public License along with                                  
- * this program. If not, see <http://www.gnu.org/licenses/>.                                                     
- *                                                                                                               
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
- * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
- * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
- * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.icgc.dcc.repository.song.reader;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -26,6 +27,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
+
+import static org.icgc.dcc.repository.song.model.AnalysisStates.PUBLISHED;
+import static org.icgc.dcc.repository.song.model.AnalysisStates.SUPPRESSED;
 
 @Slf4j
 @Ignore("For development only")
@@ -53,15 +57,11 @@ public class SongClientTest {
   }
 
   @Test
-  public void testGetStudyNode() throws IOException {
-    val node = c.getStudy("ABC123");
-    log.info("json=" + node.toString());
-  }
-
-  @Test
   public void testReadAnalysis() {
-    val r = c.readAnalyses();
+    val analysisStates = ImmutableSet.of(PUBLISHED);
+    val r = c.readAnalyses(analysisStates);
     log.info("Found these analyses:" + r.toString());
   }
+
 
 }

--- a/dcc-repository-song/src/test/resources/ABC123/analyses.json
+++ b/dcc-repository-song/src/test/resources/ABC123/analyses.json
@@ -3,13 +3,7 @@
     "analysisType": "variantCall",
     "info": "{}",
     "analysisId": "AN1",
-    "study": {
-      "info": "{}",
-      "studyId": "ABC123",
-      "name": "X1-CA",
-      "organization": "Sample Data Research Institute",
-      "description": "A fictional study"
-    },
+    "study": "ABC123",
     "analysisState": "UNPUBLISHED",
     "sample": [
       {
@@ -92,13 +86,7 @@
     "analysisType": "sequencingRead",
     "info": "{}",
     "analysisId": "AN2",
-    "study": {
-      "info": "{}",
-      "studyId": "ABC123",
-      "name": "X1-CA",
-      "organization": "Sample Data Research Institute",
-      "description": "A fictional study"
-    },
+    "study": "ABC123",
     "analysisState": "UNPUBLISHED",
     "sample": [
       {


### PR DESCRIPTION
- By default AWS and COLLAB only search for PUBLISHED studies
- the song client readAnalyses now
accepts a set of analysis states to search
 - corrected payloads and simplified for studyId

Related to overture-stack/song#317