### PR TITLE
Feature/quick merge non null fix

### DIFF
--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/AnalysisMethodCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/AnalysisMethodCombiner.java
@@ -1,0 +1,16 @@
+package org.icgc.dcc.repository.client.combiner;
+
+import lombok.val;
+import org.icgc.dcc.repository.core.model.RepositoryFile;
+
+import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+
+public class AnalysisMethodCombiner implements Combineable<RepositoryFile.AnalysisMethod> {
+  @Override
+  public RepositoryFile.AnalysisMethod merge(Iterable<RepositoryFile.AnalysisMethod> items) {
+    val a = new RepositoryFile.AnalysisMethod();
+    accumulateFirstNonNull(items, RepositoryFile.AnalysisMethod::getAnalysisType, RepositoryFile.AnalysisMethod::setAnalysisType, a);
+    accumulateFirstNonNull(items, RepositoryFile.AnalysisMethod::getSoftware, RepositoryFile.AnalysisMethod::setSoftware, a);
+    return a;
+  }
+}

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/AnalysisMethodCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/AnalysisMethodCombiner.java
@@ -1,16 +1,16 @@
 package org.icgc.dcc.repository.client.combiner;
 
 import lombok.val;
-import org.icgc.dcc.repository.core.model.RepositoryFile;
+import org.icgc.dcc.repository.core.model.RepositoryFile.AnalysisMethod;
 
-import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+import static org.icgc.dcc.repository.client.combiner.Combineable.combineFirstNonNull;
 
-public class AnalysisMethodCombiner implements Combineable<RepositoryFile.AnalysisMethod> {
+public class AnalysisMethodCombiner implements Combineable<AnalysisMethod> {
   @Override
-  public RepositoryFile.AnalysisMethod merge(Iterable<RepositoryFile.AnalysisMethod> items) {
-    val a = new RepositoryFile.AnalysisMethod();
-    accumulateFirstNonNull(items, RepositoryFile.AnalysisMethod::getAnalysisType, RepositoryFile.AnalysisMethod::setAnalysisType, a);
-    accumulateFirstNonNull(items, RepositoryFile.AnalysisMethod::getSoftware, RepositoryFile.AnalysisMethod::setSoftware, a);
-    return a;
+  public AnalysisMethod combine(Iterable<AnalysisMethod> items) {
+    val combinedValue = new AnalysisMethod();
+    combineFirstNonNull(items, AnalysisMethod::getAnalysisType, AnalysisMethod::setAnalysisType, combinedValue);
+    combineFirstNonNull(items, AnalysisMethod::getSoftware, AnalysisMethod::setSoftware, combinedValue);
+    return combinedValue;
   }
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/Combineable.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/Combineable.java
@@ -1,0 +1,21 @@
+package org.icgc.dcc.repository.client.combiner;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static java.util.Objects.isNull;
+import static org.icgc.dcc.common.core.util.stream.Streams.stream;
+
+public interface Combineable<T>{
+
+  static <T,R> void accumulateFirstNonNull(Iterable<T> items, Function<T, R> getter, BiConsumer<T, R> setter, T accumulator){
+    setter.accept(accumulator,
+        stream(items)
+            .map(getter)
+            .filter(x -> !isNull(x))
+            .findFirst()
+            .orElse(null));
+  }
+
+  T merge(Iterable<T> items);
+}

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/Combineable.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/Combineable.java
@@ -8,7 +8,7 @@ import static org.icgc.dcc.common.core.util.stream.Streams.stream;
 
 public interface Combineable<T>{
 
-  static <T,R> void accumulateFirstNonNull(Iterable<T> items, Function<T, R> getter, BiConsumer<T, R> setter, T accumulator){
+  static <T,R> void combineFirstNonNull(Iterable<T> items, Function<T, R> getter, BiConsumer<T, R> setter, T accumulator){
     setter.accept(accumulator,
         stream(items)
             .map(getter)
@@ -17,5 +17,5 @@ public interface Combineable<T>{
             .orElse(null));
   }
 
-  T merge(Iterable<T> items);
+  T combine(Iterable<T> items);
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataBundleCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataBundleCombiner.java
@@ -1,0 +1,14 @@
+package org.icgc.dcc.repository.client.combiner;
+
+import lombok.val;
+import org.icgc.dcc.repository.core.model.RepositoryFile;
+
+import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+
+public class DataBundleCombiner implements Combineable<RepositoryFile.DataBundle> {
+  @Override public RepositoryFile.DataBundle merge(Iterable<RepositoryFile.DataBundle> items) {
+    val d = new RepositoryFile.DataBundle();
+    accumulateFirstNonNull(items, RepositoryFile.DataBundle::getDataBundleId, RepositoryFile.DataBundle::setDataBundleId, d);
+    return d;
+  }
+}

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataBundleCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataBundleCombiner.java
@@ -1,14 +1,14 @@
 package org.icgc.dcc.repository.client.combiner;
 
 import lombok.val;
-import org.icgc.dcc.repository.core.model.RepositoryFile;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataBundle;
 
-import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+import static org.icgc.dcc.repository.client.combiner.Combineable.combineFirstNonNull;
 
-public class DataBundleCombiner implements Combineable<RepositoryFile.DataBundle> {
-  @Override public RepositoryFile.DataBundle merge(Iterable<RepositoryFile.DataBundle> items) {
-    val d = new RepositoryFile.DataBundle();
-    accumulateFirstNonNull(items, RepositoryFile.DataBundle::getDataBundleId, RepositoryFile.DataBundle::setDataBundleId, d);
-    return d;
+public class DataBundleCombiner implements Combineable<DataBundle> {
+  @Override public DataBundle combine(Iterable<DataBundle> items) {
+    val combinedValue = new DataBundle();
+    combineFirstNonNull(items, DataBundle::getDataBundleId, DataBundle::setDataBundleId, combinedValue);
+    return combinedValue;
   }
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataCategorizationCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataCategorizationCombiner.java
@@ -1,0 +1,15 @@
+package org.icgc.dcc.repository.client.combiner;
+
+import lombok.val;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataCategorization;
+
+import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+
+public class DataCategorizationCombiner implements Combineable<DataCategorization> {
+  @Override public DataCategorization merge(Iterable<DataCategorization> items) {
+    val d = new DataCategorization();
+    accumulateFirstNonNull(items, DataCategorization::getDataType, DataCategorization::setDataType, d);
+    accumulateFirstNonNull(items, DataCategorization::getExperimentalStrategy, DataCategorization::setExperimentalStrategy, d);
+    return d;
+  }
+}

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataCategorizationCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/DataCategorizationCombiner.java
@@ -3,13 +3,13 @@ package org.icgc.dcc.repository.client.combiner;
 import lombok.val;
 import org.icgc.dcc.repository.core.model.RepositoryFile.DataCategorization;
 
-import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+import static org.icgc.dcc.repository.client.combiner.Combineable.combineFirstNonNull;
 
 public class DataCategorizationCombiner implements Combineable<DataCategorization> {
-  @Override public DataCategorization merge(Iterable<DataCategorization> items) {
-    val d = new DataCategorization();
-    accumulateFirstNonNull(items, DataCategorization::getDataType, DataCategorization::setDataType, d);
-    accumulateFirstNonNull(items, DataCategorization::getExperimentalStrategy, DataCategorization::setExperimentalStrategy, d);
-    return d;
+  @Override public DataCategorization combine(Iterable<DataCategorization> items) {
+    val combinedValue = new DataCategorization();
+    combineFirstNonNull(items, DataCategorization::getDataType, DataCategorization::setDataType, combinedValue);
+    combineFirstNonNull(items, DataCategorization::getExperimentalStrategy, DataCategorization::setExperimentalStrategy, combinedValue);
+    return combinedValue;
   }
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/ReferenceGenomeCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/ReferenceGenomeCombiner.java
@@ -1,0 +1,16 @@
+package org.icgc.dcc.repository.client.combiner;
+
+import lombok.val;
+import org.icgc.dcc.repository.core.model.RepositoryFile.ReferenceGenome;
+
+import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+
+public class ReferenceGenomeCombiner implements Combineable<ReferenceGenome> {
+  @Override public ReferenceGenome merge(Iterable<ReferenceGenome> items) {
+    val r = new ReferenceGenome();
+    accumulateFirstNonNull(items, ReferenceGenome::getDownloadUrl, ReferenceGenome::setDownloadUrl, r);
+    accumulateFirstNonNull(items, ReferenceGenome::getGenomeBuild, ReferenceGenome::setGenomeBuild, r);
+    accumulateFirstNonNull(items, ReferenceGenome::getReferenceName, ReferenceGenome::setReferenceName, r);
+    return r;
+  }
+}

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/ReferenceGenomeCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/combiner/ReferenceGenomeCombiner.java
@@ -3,14 +3,14 @@ package org.icgc.dcc.repository.client.combiner;
 import lombok.val;
 import org.icgc.dcc.repository.core.model.RepositoryFile.ReferenceGenome;
 
-import static org.icgc.dcc.repository.client.combiner.Combineable.accumulateFirstNonNull;
+import static org.icgc.dcc.repository.client.combiner.Combineable.combineFirstNonNull;
 
 public class ReferenceGenomeCombiner implements Combineable<ReferenceGenome> {
-  @Override public ReferenceGenome merge(Iterable<ReferenceGenome> items) {
-    val r = new ReferenceGenome();
-    accumulateFirstNonNull(items, ReferenceGenome::getDownloadUrl, ReferenceGenome::setDownloadUrl, r);
-    accumulateFirstNonNull(items, ReferenceGenome::getGenomeBuild, ReferenceGenome::setGenomeBuild, r);
-    accumulateFirstNonNull(items, ReferenceGenome::getReferenceName, ReferenceGenome::setReferenceName, r);
-    return r;
+  @Override public ReferenceGenome combine(Iterable<ReferenceGenome> items) {
+    val combinedValue = new ReferenceGenome();
+    combineFirstNonNull(items, ReferenceGenome::getDownloadUrl, ReferenceGenome::setDownloadUrl, combinedValue);
+    combineFirstNonNull(items, ReferenceGenome::getGenomeBuild, ReferenceGenome::setGenomeBuild, combinedValue);
+    combineFirstNonNull(items, ReferenceGenome::getReferenceName, ReferenceGenome::setReferenceName, combinedValue);
+    return combinedValue;
   }
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.icgc.dcc.common.core.util.function.Predicates.distinctByKey;
+import static org.icgc.dcc.common.core.util.function.Predicates.isNotNull;
 import static org.icgc.dcc.repository.core.util.RepositoryFiles.inPCAWGOrder;
 
 @Slf4j
@@ -147,7 +148,10 @@ public class RepositoryFileCombiner {
 
   private static <T> T combineField(Collection<T> values) {
     // Try to find first non-null
-    return values.stream().filter(value -> value != null).findFirst().orElse(null);
+    return values.stream()
+        .filter(isNotNull())
+        .findFirst()
+        .orElse(null);
   }
 
   private static Set<RepositoryFile> prioritize(Set<RepositoryFile> files) {
@@ -157,11 +161,19 @@ public class RepositoryFileCombiner {
   }
 
   private static <T> List<T> get(Collection<RepositoryFile> files, Function<RepositoryFile, T> getter) {
-    return files.stream().map(getter).collect(toList());
+    return files.stream()
+        .filter(isNotNull())
+        .map(getter)
+        .collect(toList());
   }
 
   private static <T> List<T> getAll(Collection<RepositoryFile> files, Function<RepositoryFile, List<T>> getter) {
-    return files.stream().flatMap(file -> getter.apply(file).stream()).collect(toList());
+    return files.stream()
+        .filter(isNotNull())
+        .map(getter)
+        .filter(isNotNull())
+        .flatMap(Collection::stream)
+        .collect(toList());
   }
 
 }

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
@@ -17,9 +17,18 @@
  */
 package org.icgc.dcc.repository.client.core;
 
-import static java.util.stream.Collectors.toList;
-import static org.icgc.dcc.common.core.util.function.Predicates.distinctByKey;
-import static org.icgc.dcc.repository.core.util.RepositoryFiles.inPCAWGOrder;
+import com.google.common.collect.Sets;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.icgc.dcc.repository.client.combiner.AnalysisMethodCombiner;
+import org.icgc.dcc.repository.client.combiner.DataBundleCombiner;
+import org.icgc.dcc.repository.client.combiner.DataCategorizationCombiner;
+import org.icgc.dcc.repository.client.combiner.ReferenceGenomeCombiner;
+import org.icgc.dcc.repository.core.RepositoryFileContext;
+import org.icgc.dcc.repository.core.model.RepositoryFile;
+import org.icgc.dcc.repository.core.model.RepositoryFile.Donor;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -28,19 +37,19 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.icgc.dcc.repository.core.RepositoryFileContext;
-import org.icgc.dcc.repository.core.model.RepositoryFile;
-
-import com.google.common.collect.Sets;
-
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
-import lombok.extern.slf4j.Slf4j;
+import static java.util.stream.Collectors.toList;
+import static org.icgc.dcc.common.core.util.function.Predicates.distinctByKey;
+import static org.icgc.dcc.repository.core.util.RepositoryFiles.inPCAWGOrder;
 
 @Slf4j
 @RequiredArgsConstructor
 public class RepositoryFileCombiner {
+
+  private static final AnalysisMethodCombiner ANALYSIS_METHOD_COMBINER = new AnalysisMethodCombiner();
+  private static final DataBundleCombiner DATA_BUNDLE_COMBINER = new DataBundleCombiner();
+  private static final DataCategorizationCombiner DATA_CATEGORIZATION_COMBINER = new DataCategorizationCombiner();
+  private static final ReferenceGenomeCombiner REFERENCE_GENOME_COMBINER = new ReferenceGenomeCombiner();
+
 
   /**
    * Dependencies.
@@ -76,7 +85,7 @@ public class RepositoryFileCombiner {
     };
   }
 
-  private RepositoryFile combineFiles(Set<RepositoryFile> files) {
+  RepositoryFile combineFiles(Set<RepositoryFile> files) {
     // TODO: Add checks for all root fields and very least add reporting for inconsistent fields, if not fail processing
     val prioritizedFiles = prioritize(files);
 
@@ -94,24 +103,24 @@ public class RepositoryFileCombiner {
     analyzeField(files, "objectId", objectIds);
     combinedFile.setObjectId(combineField(objectIds));
 
-    val studies = get(prioritizedFiles, RepositoryFile::getStudy);
-    combinedFile.setStudy(combineField(studies));
+    val studies = getAll(prioritizedFiles, RepositoryFile::getStudy);
+    combinedFile.setStudy(studies);
 
     val accesses = get(prioritizedFiles, RepositoryFile::getAccess);
     analyzeField(files, "access", accesses);
     combinedFile.setAccess(combineField(accesses));
 
     val dataBundles = get(prioritizedFiles, RepositoryFile::getDataBundle);
-    combinedFile.setDataBundle(combineField(dataBundles));
+    combinedFile.setDataBundle(DATA_BUNDLE_COMBINER.merge(dataBundles));
 
     val analysisMethods = get(prioritizedFiles, RepositoryFile::getAnalysisMethod);
-    combinedFile.setAnalysisMethod(combineField(analysisMethods));
+    combinedFile.setAnalysisMethod(ANALYSIS_METHOD_COMBINER.merge(analysisMethods));
 
     val dataCategorizations = get(prioritizedFiles, RepositoryFile::getDataCategorization);
-    combinedFile.setDataCategorization(combineField(dataCategorizations));
+    combinedFile.setDataCategorization(DATA_CATEGORIZATION_COMBINER.merge(dataCategorizations));
 
     val referenceGenomes = get(prioritizedFiles, RepositoryFile::getReferenceGenome);
-    combinedFile.setReferenceGenome(combineField(referenceGenomes));
+    combinedFile.setReferenceGenome(REFERENCE_GENOME_COMBINER.merge(referenceGenomes));
 
     //
     // Combine All
@@ -121,7 +130,7 @@ public class RepositoryFileCombiner {
     combinedFile.setFileCopies(fileCopies);
 
     val uniqueDonors = getAll(prioritizedFiles, RepositoryFile::getDonors).stream()
-        .filter(distinctByKey(d -> d.getDonorId()))
+        .filter(distinctByKey(Donor::getDonorId))
         .collect(toList());
     combinedFile.setDonors(uniqueDonors);
 

--- a/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
+++ b/dcc-repository-client/src/main/java/org/icgc/dcc/repository/client/core/RepositoryFileCombiner.java
@@ -111,16 +111,16 @@ public class RepositoryFileCombiner {
     combinedFile.setAccess(combineField(accesses));
 
     val dataBundles = get(prioritizedFiles, RepositoryFile::getDataBundle);
-    combinedFile.setDataBundle(DATA_BUNDLE_COMBINER.merge(dataBundles));
+    combinedFile.setDataBundle(DATA_BUNDLE_COMBINER.combine(dataBundles));
 
     val analysisMethods = get(prioritizedFiles, RepositoryFile::getAnalysisMethod);
-    combinedFile.setAnalysisMethod(ANALYSIS_METHOD_COMBINER.merge(analysisMethods));
+    combinedFile.setAnalysisMethod(ANALYSIS_METHOD_COMBINER.combine(analysisMethods));
 
     val dataCategorizations = get(prioritizedFiles, RepositoryFile::getDataCategorization);
-    combinedFile.setDataCategorization(DATA_CATEGORIZATION_COMBINER.merge(dataCategorizations));
+    combinedFile.setDataCategorization(DATA_CATEGORIZATION_COMBINER.combine(dataCategorizations));
 
     val referenceGenomes = get(prioritizedFiles, RepositoryFile::getReferenceGenome);
-    combinedFile.setReferenceGenome(REFERENCE_GENOME_COMBINER.merge(referenceGenomes));
+    combinedFile.setReferenceGenome(REFERENCE_GENOME_COMBINER.combine(referenceGenomes));
 
     //
     // Combine All

--- a/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/CombinerTest.java
+++ b/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/CombinerTest.java
@@ -1,0 +1,5 @@
+package org.icgc.dcc.repository.client.core;
+
+public class CombinerTest {
+
+}

--- a/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/CombinerTest.java
+++ b/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/CombinerTest.java
@@ -1,5 +1,0 @@
-package org.icgc.dcc.repository.client.core;
-
-public class CombinerTest {
-
-}

--- a/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/FirstNonNullCombinerTest.java
+++ b/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/FirstNonNullCombinerTest.java
@@ -1,0 +1,194 @@
+package org.icgc.dcc.repository.client.core;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Singular;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.icgc.dcc.repository.client.combiner.AnalysisMethodCombiner;
+import org.icgc.dcc.repository.client.combiner.Combineable;
+import org.icgc.dcc.repository.client.combiner.DataBundleCombiner;
+import org.icgc.dcc.repository.client.combiner.DataCategorizationCombiner;
+import org.icgc.dcc.repository.client.combiner.ReferenceGenomeCombiner;
+import org.icgc.dcc.repository.core.model.RepositoryFile.AnalysisMethod;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataBundle;
+import org.icgc.dcc.repository.core.model.RepositoryFile.DataCategorization;
+import org.icgc.dcc.repository.core.model.RepositoryFile.ReferenceGenome;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.icgc.dcc.common.core.util.stream.Collectors.toImmutableList;
+import static org.icgc.dcc.common.core.util.stream.Streams.stream;
+
+/**
+ * Tests that each combiner returns the first non-null result in a list of entities.
+ *
+ *    - each tX is a new object
+ *    - t0 is first, t1 is second, t2 third and t3 last
+ *   +---------+------+------+------+------+--------+
+ *   | seqnum | t0   | t1   | t2   | t3   | result |
+ *   +---------+------+------+------+------+--------+
+ *   | 1       | null | null | null | A    | A      |
+ *   +---------+------+------+------+------+--------+
+ *   | 2       | null | null | B    | null | B      |
+ *   +---------+------+------+------+------+--------+
+ *   | 3       | null | null | B    | A    | B      |
+ *   +---------+------+------+------+------+--------+
+ *   | 4       | null | C    | null | null | C      |
+ *   +---------+------+------+------+------+--------+
+ *   | 5       | null | C    | null | A    | C      |
+ *   +---------+------+------+------+------+--------+
+ *   | 6       | null | C    | B    | null | C      |
+ *   +---------+------+------+------+------+--------+
+ *   | 7       | null | C    | B    | A    | C      |
+ *   +---------+------+------+------+------+--------+
+ *   | 8       | D    | null | null | null | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 9       | D    | null | null | A    | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 10      | D    | null | B    | null | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 11      | D    | null | B    | A    | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 12      | D    | C    | null | null | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 13      | D    | C    | null | A    | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 14      | D    | C    | B    | null | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 15      | D    | C    | B    | A    | D      |
+ *   +---------+------+------+------+------+--------+
+ *   | 16      | null | null | null | null | null   |
+ *   +---------+------+------+------+------+--------+
+ */
+
+@Slf4j
+public class FirstNonNullCombinerTest {
+
+  private static final int NUM_POSITIONS = 4;
+
+  private final Generator generator = new Generator(NUM_POSITIONS);
+
+  @Test
+  public void testAnalysisMethodCombiner() {
+    runTest(generator::generateAnalysisMethodTC, new AnalysisMethodCombiner());
+  }
+
+  @Test
+  public void testDataCategorizationCombiner() {
+    runTest(generator::generateDataCategorizationTC, new DataCategorizationCombiner());
+  }
+
+  @Test
+  public void testDataBundleCombiner() {
+    runTest(generator::generateDataBundleTC, new DataBundleCombiner());
+  }
+
+  @Test
+  public void testReferenceGenomeCombiner() {
+    runTest(generator::generateReferenceGenomeTC, new ReferenceGenomeCombiner());
+  }
+
+  private <T> void runTest(Function<Integer, TestCase<T>> function, Combineable<T> combiner) {
+    val results = range(1,1<<NUM_POSITIONS)
+        .boxed()
+        .map(function)
+        .collect(toList());
+    for (val r : results){
+      val out = combiner.merge(r.getInputs());
+      assertThat(out).isEqualTo(r.getExpected());
+    }
+  }
+
+  @Builder
+  @Value
+  public static class TestCase<T>{
+    @NonNull private final T expected;
+    @NonNull @Singular private final List<T> inputs;
+  }
+
+  @RequiredArgsConstructor
+  public static class Generator {
+
+    private final int numPositions;
+    private int count=0;
+    private final Random r = new Random();
+
+    public TestCase<AnalysisMethod> generateAnalysisMethodTC(int seqNum) {
+      return generate(seqNum, AnalysisMethod::new, AnalysisMethod::setAnalysisType, AnalysisMethod::setSoftware);
+    }
+
+    public TestCase<DataBundle> generateDataBundleTC(int seqNum) {
+      return generate(seqNum, DataBundle::new, DataBundle::setDataBundleId);
+    }
+
+    public TestCase<DataCategorization> generateDataCategorizationTC(int seqNum) {
+      return generate(seqNum, DataCategorization::new,
+          DataCategorization::setDataType, DataCategorization::setExperimentalStrategy);
+    }
+
+    public TestCase<ReferenceGenome> generateReferenceGenomeTC(int seqNum) {
+      return generate(seqNum, ReferenceGenome::new,
+          ReferenceGenome::setDownloadUrl, ReferenceGenome::setReferenceName, ReferenceGenome::setGenomeBuild);
+    }
+
+    private <T> TestCase<T> generate(int seqnum, Supplier<T> constructor, BiConsumer<T, String> ...consumers){
+      val expectedPos = getExpectedPos(seqnum, numPositions);
+      val inputs = range(1, numPositions +1)
+          .boxed()
+          .map(pos -> internalGenerate(seqnum, pos, constructor, consumers))
+          .collect(toImmutableList());
+      return TestCase.<T>builder()
+          .inputs(inputs)
+          .expected(inputs.get(expectedPos-1))
+          .build();
+    }
+
+    private <T> T internalGenerate(int seqnum, int pos, Supplier<T> constructor, BiConsumer<T, String> ...consumers){
+      T d = constructor.get();
+      stream(consumers).forEach(c -> c.accept(d, getStringValue(seqnum, pos)));
+      return d;
+    }
+
+    // highest bit is the lowest position
+    private String getStringValue(int seqnum, int pos){
+      if (pos < 1){
+        return null;
+      } else {
+        if (((seqnum >> (numPositions - pos)) & 0x1) == 1){
+          return r.nextInt()+"something"+(count++);
+        } else {
+          return null;
+
+        }
+      }
+    }
+
+    // highest bit is the lowest position
+    private int getExpectedPos(final int sequenceNumber, final int bw){
+      int pos = bw;
+      int mask = 1<<(bw-1);
+      while (mask>0){
+        if (sequenceNumber < mask){
+          mask >>= 1;
+          pos--;
+        } else {
+          return (numPositions - pos +1);
+        }
+      }
+      return -1;
+    }
+
+  }
+
+}

--- a/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/FirstNonNullCombinerTest.java
+++ b/dcc-repository-client/src/test/java/org/icgc/dcc/repository/client/core/FirstNonNullCombinerTest.java
@@ -105,7 +105,7 @@ public class FirstNonNullCombinerTest {
         .map(function)
         .collect(toList());
     for (val r : results){
-      val out = combiner.merge(r.getInputs());
+      val out = combiner.combine(r.getInputs());
       assertThat(out).isEqualTo(r.getExpected());
     }
   }


### PR DESCRIPTION
fixed issues with combining of non-string fields (i.e object fields).  Previously was comparing on non-null, however an uninitialised object is non-null.

Related to icgc-dcc/dcc-portal#514
